### PR TITLE
www-redirects app

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,81 @@
+# Deploy www-redirects on cloud.gov
+---
+name: deploy
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  deploy-development:
+    if: github.ref == 'refs/heads/develop'
+    name: deploy (development)
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: deploy
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push www-redirects --vars-file vars.development.yml --strategy rolling
+          org: gsa-datagov
+          space: development
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: |
+          sleep 10
+          timestamp=$(date +%s)
+          host=www-redirects-dev-datagov.app.cloud.gov
+          [ "301 https://www.data.gov/test?${timestamp}" = "$(curl --output /dev/null --write-out '%{http_code} %{redirect_url}' --fail --silent https://${host}/test?${timestamp})" ]
+
+  deploy-staging:
+    if: github.ref == 'refs/heads/main'
+    name: deploy (staging)
+    environment: staging
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: deploy
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push www-redirects --vars-file vars.staging.yml --strategy rolling
+          org: gsa-datagov
+          space: staging
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: |
+          sleep 10
+          timestamp=$(date +%s)
+          host=www-redirects-stage-datagov.app.cloud.gov
+          [ "301 https://www.data.gov/test?${timestamp}" = "$(curl --output /dev/null --write-out '%{http_code} %{redirect_url}' --fail --silent https://${host}/test?${timestamp})" ]
+
+  deploy-production:
+    if: github.ref == 'refs/heads/main'
+    name: deploy (production)
+    needs:
+      - deploy-staging
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: deploy
+        uses: usds/cloud-gov-cli@master
+        with:
+          command: push www-redirects --vars-file vars.production.yml --strategy rolling
+          org: gsa-datagov
+          space: prod
+          user: ${{secrets.CF_SERVICE_USER}}
+          password: ${{secrets.CF_SERVICE_AUTH}}
+      - name: smoke test
+        run: |
+          sleep 10
+          timestamp=$(date +%s)
+          host=www-redirects-prod-datagov.app.cloud.gov
+          [ "301 https://www.data.gov/test?${timestamp}" = "$(curl --output /dev/null --write-out '%{http_code} %{redirect_url}' --fail --silent https://${host}/test?${timestamp})" ]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,28 @@ Open your web browser to [localhost:4000](http://localhost:4000/).
 Run some checks.
 
     $ npm run lint
+
+## www-redirects
+
+A tiny nginx application that redirects URLs from our subdomains to
+www.data.gov.
+
+
+### Services
+
+These services are required.
+
+    $ cf create-service external-domain domain www-redirects-domains -c '{"domains": "agriculture.data.gov,climate.data.gov,developer.data.gov,energy.data.gov,food.data.gov,highlights.data.gov,labs.data.gov,ocean.data.gov"}'
+
+
+### Continuous Delivery
+
+The www-redirects applicaiton is automatically deployed from CI. Make sure to
+create deployer secrets.
+
+Secret | Description | Where to find?
+------ | ----------- | --------------
+CF_SERVICE_USER | The deployer username. | cf service-key
+CF_SERVICE_AUTH | The deployer password. | cf service-key
+
+

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,11 @@
+---
+applications:
+  - name: ((app_name))
+    path: redirects
+    instances: ((instances))
+    memory: ((memory))
+    buildpacks:
+      - https://github.com/cloudfoundry/nginx-buildpack.git
+    routes: ((routes))
+    env:
+      TARGET_DOMAIN: www.data.gov

--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -1,0 +1,16 @@
+worker_processes 1;
+daemon off;
+
+error_log stderr;
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen {{port}};
+    server_name localhost;
+    access_log /dev/stdout combined;
+
+    expires 3600;
+    return 301 https://{{ env "TARGET_DOMAIN" }}$request_uri;
+  }
+}

--- a/vars.development.yml
+++ b/vars.development.yml
@@ -1,0 +1,5 @@
+app_name: www-redirects
+instances: 0
+memory: 64M
+routes:
+  - route: www-redirects-dev-datagov.app.cloud.gov

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -1,0 +1,5 @@
+app_name: www-redirects
+instances: 2
+memory: 64M
+routes:
+  - route: www-redirects-prod-datagov.app.cloud.gov

--- a/vars.staging.yml
+++ b/vars.staging.yml
@@ -1,0 +1,5 @@
+app_name: www-redirects
+instances: 1
+memory: 64M
+routes:
+  - route: www-redirects-stage-datagov.app.cloud.gov


### PR DESCRIPTION
https://github.com/gsa/datagov-deploy/issues/3497

Create a simple nginx app that will redirect subdomains (climate.data.gov) to
the main site (www.data.gov).

In order to create the external domain service in cloud.gov, we need to update
the CNAMES in DNS.
