### PR TITLE
Maintain path in dashboard redirect

### DIFF
--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -10,7 +10,7 @@ http {
 
   server {
     listen {{port}} default_server;
-    server_name localhost;
+    server_name _;
 
     return 301 https://{{ env "TARGET_DOMAIN" }}$request_uri;
   }
@@ -62,8 +62,8 @@ http {
     listen {{port}};
     server_name labs.data.gov;
 
-    location /dashboard {
-      return 301 https://dashboard.data.gov/;
+    location ~ /dashboard/(.*) {
+      return 302 https://dashboard.data.gov/$1;
     }
 
     location / {


### PR DESCRIPTION
https://github.com/gsa/datagov-deploy/issues/3555

Requests like labs.data.gov/dashboard/blah should be redirected to
dashboard.data.gov/blah, not the dashboard home page.

Use a 302 just in case we get it wrong ;)
