### PR TITLE
cleaned up redirects removed from 18f/dns

### DIFF
--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -17,24 +17,9 @@ http {
 
   server {
     listen {{port}};
-    server_name agriculture.data.gov;
-
-    # yes, agriculture redirects to food
-    return 301 https://{{ env "TARGET_DOMAIN" }}/food/;
-  }
-
-  server {
-    listen {{port}};
     server_name climate.data.gov;
 
     return 301 https://{{ env "TARGET_DOMAIN" }}/climate/;
-  }
-
-  server {
-    listen {{port}};
-    server_name energy.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/energy/;
   }
 
   server {

--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -17,9 +17,24 @@ http {
 
   server {
     listen {{port}};
+    server_name agriculture.data.gov;
+
+    # yes, agriculture redirects to food
+    return 301 https://{{ env "TARGET_DOMAIN" }}/food/;
+  }
+
+  server {
+    listen {{port}};
     server_name climate.data.gov;
 
     return 301 https://{{ env "TARGET_DOMAIN" }}/climate/;
+  }
+
+  server {
+    listen {{port}};
+    server_name energy.data.gov;
+
+    return 301 https://{{ env "TARGET_DOMAIN" }}/energy/;
   }
 
   server {

--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -17,65 +17,9 @@ http {
 
   server {
     listen {{port}};
-    server_name agriculture.data.gov;
-
-    # yes, agriculture redirects to food
-    return 301 https://{{ env "TARGET_DOMAIN" }}/food/;
-  }
-
-  server {
-    listen {{port}};
     server_name climate.data.gov;
 
     return 301 https://{{ env "TARGET_DOMAIN" }}/climate/;
-  }
-
-  server {
-    listen {{port}};
-    server_name developer.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/developers/;
-  }
-
-  server {
-    listen {{port}};
-    server_name energy.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/energy/;
-  }
-
-  server {
-    listen {{port}};
-    server_name food.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/food/;
-  }
-
-  server {
-    listen {{port}};
-    server_name highlights.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/highlights/;
-  }
-
-  server {
-    listen {{port}};
-    server_name labs.data.gov;
-
-    location ~ ^/dashboard(/.*)?$ {
-      return 302 https://dashboard.data.gov$1;
-    }
-
-    location / {
-      return 301 https://{{ env "TARGET_DOMAIN" }}/labs/;
-    }
-  }
-
-  server {
-    listen {{port}};
-    server_name ocean.data.gov;
-
-    return 301 https://{{ env "TARGET_DOMAIN" }}/ocean/;
   }
 
   server {


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4233

Cleans up redirects that were removed from 18f/dns. 

Please confirm @FuhuXia  that these look correct. 