### PR TITLE
Dashboard redirects

### DIFF
--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -24,6 +24,17 @@ http {
 
   server {
     listen {{port}};
+    server_name dashboard.data.gov;
+
+    location /validate {
+        return 301 https://catalog.data.gov/dcat-us/validator;
+    }
+
+    return 301 https://catalog.data.gov/reports;
+  }
+
+  server {
+    listen {{port}};
     server_name www.data.gov;
 
     return 301 https://{{ env "TARGET_DOMAIN" }}$request_uri;

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -4,4 +4,6 @@ memory: 64M
 routes:
   - route: www-redirects-prod-datagov.app.cloud.gov
   - route: climate.data.gov
+  - route: dashboard.data.gov
+  - route: dashboard-prod-datagov.app.cloud.gov
   - route: www.data.gov

--- a/vars.production.yml
+++ b/vars.production.yml
@@ -5,5 +5,4 @@ routes:
   - route: www-redirects-prod-datagov.app.cloud.gov
   - route: climate.data.gov
   - route: dashboard.data.gov
-  - route: dashboard-prod-datagov.app.cloud.gov
   - route: www.data.gov


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4331 and https://github.com/GSA/data.gov/issues/4001. Combines https://github.com/GSA/datagov-website/pull/47 and https://github.com/GSA/datagov-website/pull/48.

This PR will cut dashboard over to catalog `/dcat-us/validator` and `/reports`. 