### PR TITLE
dashboard should redirect to https://catalog.data.gov/report/metrics-dashboard

### DIFF
--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -30,7 +30,7 @@ http {
         return 301 https://catalog.data.gov/dcat-us/validator;
     }
 
-    return 301 https://catalog.data.gov/reports/metrics-dashboard;
+    return 301 https://catalog.data.gov/report/metrics-dashboard;
   }
 
   server {

--- a/redirects/nginx.conf
+++ b/redirects/nginx.conf
@@ -30,7 +30,7 @@ http {
         return 301 https://catalog.data.gov/dcat-us/validator;
     }
 
-    return 301 https://catalog.data.gov/reports;
+    return 301 https://catalog.data.gov/reports/metrics-dashboard;
   }
 
   server {


### PR DESCRIPTION
I followed the sketch too literally.

Related to https://github.com/GSA/datagov-website/pull/50 & https://github.com/GSA/data.gov/issues/4331